### PR TITLE
refactor(*): rustc 1.0.0-beta.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,17 +8,21 @@ keywords = ["json", "validator", "json-schema"]
 license = "MIT"
 documentation = "http://rustless.org/valico/doc/valico/"
 homepage = "https://github.com/rustless/valico"
+build = "build.rs"
 
 [dependencies]
 regex = "*"
-regex_macros = "*"
 rustc-serialize = "*"
 url = "*"
-mopa = "*"
 jsonway = "*"
 uuid = "*"
 phf = "*"
-phf_macros = "*"
+lazy_static = "0.1.10"
+typeable = "*"
+traitobject = "*"
+
+[build-dependencies.phf_codegen]
+version = "*"
 
 [[test]]
 name = "tests"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,14 +12,13 @@ build = "build.rs"
 
 [dependencies]
 regex = "*"
+lazy_static = "0.1.10"
 rustc-serialize = "*"
 url = "*"
+mopa = "*"
 jsonway = "*"
 uuid = "*"
 phf = "*"
-lazy_static = "0.1.10"
-typeable = "*"
-traitobject = "*"
 
 [build-dependencies.phf_codegen]
 version = "*"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,52 @@
+extern crate phf_codegen;
+
+use std::fs::File;
+use std::io::{BufWriter, Write};
+use std::path::Path;
+
+fn main() {
+    let path = Path::new(env!("OUT_DIR")).join("codegen.rs");
+    let mut file = BufWriter::new(File::create(&path).unwrap());
+
+    write!(&mut file, "static PROPERTY_KEYS: phf::Set<&'static str> = ").unwrap();
+    phf_codegen::Set::new()
+        .entry("properties")
+        .entry("patternProperties")
+        .build(&mut file)
+        .unwrap();
+    write!(&mut file, ";\n").unwrap();
+
+    write!(&mut file, "static NON_SCHEMA_KEYS: phf::Set<&'static str> = ").unwrap();
+    phf_codegen::Set::new()
+        .entry("properties")
+        .entry("patternProperties")
+        .entry("dependencies")
+        .entry("definitions")
+        .entry("anyOf")
+        .entry("allOf")
+        .entry("oneOf")
+        .build(&mut file)
+        .unwrap();
+    write!(&mut file, ";\n").unwrap();
+
+    write!(&mut file, "static FINAL_KEYS: phf::Set<&'static str> = ").unwrap();
+    phf_codegen::Set::new()
+        .entry("enum")
+        .entry("required")
+        .entry("type")
+        .build(&mut file)
+        .unwrap();
+    write!(&mut file, ";\n").unwrap();
+
+    write!(&mut file, "const ALLOW_NON_CONSUMED_KEYS: phf::Set<&'static str> = ").unwrap();
+    phf_codegen::Set::new()
+        .entry("definitions")
+        .entry("$schema")
+        .entry("id")
+        .entry("default")
+        .entry("description")
+        .entry("format")
+        .build(&mut file)
+        .unwrap();
+    write!(&mut file, ";\n").unwrap();
+}

--- a/src/common/error.rs
+++ b/src/common/error.rs
@@ -1,16 +1,8 @@
+use std::error::Error;
 use rustc_serialize::json;
-use std::mem;
-use std::fmt::Debug;
-use std::any::TypeId;
-use std::error::Error as StdError;
-use typeable::Typeable;
-use traitobject;
+use mopa::Any;
 
-pub trait Error : Debug + Send + Typeable + StdError {}
-
-impl<S: StdError + Debug + Send + Typeable> Error for S {}
-
-pub trait ValicoError : Error + json::ToJson {
+pub trait ValicoError : Error + Send + Any + json::ToJson {
     fn get_code(&self) -> &str;
     fn get_path(&self) -> &str;
     fn get_title(&self) -> &str;
@@ -23,21 +15,9 @@ impl json::ToJson for Box<ValicoError> {
     }
 }
  
-impl ValicoError {
-    pub fn is<E: Error>(&self) -> bool {
-        self.get_type() == TypeId::of::<E>()
-    }
-
-    pub fn downcast<E: Error>(&self) -> Option<&E> {
-        if self.is::<E>() {
-            unsafe { Some(mem::transmute(traitobject::data(self))) }
-        } else {
-            None
-        }
-    }
-}
-
 pub type ValicoErrors = Vec<Box<ValicoError>>;
+
+mopafy!(ValicoError);
 
 macro_rules! impl_basic_err {
     ($err:ty, $code:expr) => {

--- a/src/json_dsl/builder.rs
+++ b/src/json_dsl/builder.rs
@@ -156,8 +156,8 @@ impl Builder {
             for (idx, item) in array.iter_mut().enumerate() {
                 let item_path = [path, idx.to_string().as_ref()].connect("/");
                 if item.is_object() {
-                    let mut process_state = self.process_object(item, item_path.as_ref(), scope);
-                    state.append(&mut process_state);
+                    let process_state = self.process_object(item, item_path.as_ref(), scope);
+                    state.append(process_state);
                 } else {
                     state.errors.push(
                         Box::new(errors::WrongType {
@@ -177,7 +177,7 @@ impl Builder {
                 Box::new(errors::WrongType {
                     path: path.to_string(),
                     detail: "Value is not an object or an array".to_string()
-                }) as Box<super::super::common::error::ValicoError>
+                })
             );
 
             state
@@ -193,7 +193,7 @@ impl Builder {
             let id = self.schema_id.as_ref().unwrap();
             let schema = scope.as_ref().unwrap().resolve(id);
             match schema {
-                Some(schema) => state.append(&mut schema.validate_in(val, path)),
+                Some(schema) => state.append(schema.validate_in(val, path)),
                 None => state.missing.push(id.clone())
             }
         }
@@ -212,13 +212,13 @@ impl Builder {
                 let present = helpers::has_value(object, name);
                 let param_path = [path, name.as_ref()].connect("/");
                 if present {
-                    let mut process_result = param.process(object.get_mut(name).unwrap(), param_path.as_ref(), scope);
+                    let process_result = param.process(object.get_mut(name).unwrap(), param_path.as_ref(), scope);
                     match process_result.value  {
                         Some(new_value) => { object.insert(name.clone(), new_value); },
                         None => ()
                     }
 
-                    state.append(&mut process_result.state);
+                    state.append(process_result.state);
                 } else {
                     state.errors.push(Box::new(errors::Required {
                         path: param_path.clone()
@@ -231,13 +231,13 @@ impl Builder {
                 let present = helpers::has_value(object, name);
                 let param_path = [path, name.as_ref()].connect("/");
                 if present {
-                    let mut process_result = param.process(object.get_mut(name).unwrap(), param_path.as_ref(), scope);
+                    let process_result = param.process(object.get_mut(name).unwrap(), param_path.as_ref(), scope);
                     match process_result.value  {
                         Some(new_value) => { object.insert(name.clone(), new_value); },
                         None => ()
                     }
 
-                    state.append(&mut process_result.state);
+                    state.append(process_result.state);
                 }
             }
         }
@@ -251,8 +251,8 @@ impl Builder {
         for validator in self.validators.iter() {
             match validator.validate(val, path) {
                 Ok(()) => (),
-                Err(mut err) => {
-                    state.errors.append(&mut err);
+                Err(err) => {
+                    state.errors.extend(err);
                 }
             };
         }

--- a/src/json_dsl/coercers.rs
+++ b/src/json_dsl/coercers.rs
@@ -268,8 +268,8 @@ impl ArrayCoercer {
                         array.insert(i, value);
                     },
                     Ok(None) => (),
-                    Err(mut err) => {
-                        errors.append(&mut err)
+                    Err(err) => {
+                        errors.extend(err);
                     }
                 }
             }

--- a/src/json_dsl/mod.rs
+++ b/src/json_dsl/mod.rs
@@ -70,7 +70,7 @@ impl<T> ExtendedResult<T> {
         self.state.is_valid()
     }
 
-    pub fn append(&mut self, second: &mut json_schema::ValidationState) {
+    pub fn append(&mut self, second: json_schema::ValidationState) {
         self.state.append(second);
     }
 }

--- a/src/json_dsl/param.rs
+++ b/src/json_dsl/param.rs
@@ -113,7 +113,7 @@ impl Param {
         for validator in self.validators.iter() {
             match validator.validate(val, path) {
                 Ok(()) => (),
-                Err(mut validation_errors) => errors.append(&mut validation_errors)
+                Err(validation_errors) => errors.extend(validation_errors)
             }
         };
 
@@ -137,8 +137,8 @@ impl Param {
                         return_value = Some(new_value);
                         return_value.as_mut().unwrap()
                     },
-                    Err(mut errors) => {
-                        result.state.errors.append(&mut errors);
+                    Err(errors) => {
+                        result.state.errors.extend(errors);
                         return result;
                     }
                 }
@@ -147,18 +147,18 @@ impl Param {
             };
 
             if self.nest.is_some() {
-                let mut process_state = self.nest.as_ref().unwrap().process_nest(val, path, scope);
-                result.append(&mut process_state);
+                let process_state = self.nest.as_ref().unwrap().process_nest(val, path, scope);
+                result.append(process_state);
             }
 
-            let mut validation_errors = self.process_validators(val, path);
-            result.state.errors.append(&mut validation_errors);
+            let validation_errors = self.process_validators(val, path);
+            result.state.errors.extend(validation_errors);
 
             if self.schema_id.is_some() && scope.is_some() {
                 let id = self.schema_id.as_ref().unwrap();
                 let schema = scope.as_ref().unwrap().resolve(id);
                 match schema {
-                    Some(schema) => result.append(&mut schema.validate_in(val, path)),
+                    Some(schema) => result.append(schema.validate_in(val, path)),
                     None => result.state.missing.push(id.clone())
                 }
             }

--- a/src/json_schema/keywords/format.rs
+++ b/src/json_schema/keywords/format.rs
@@ -7,7 +7,11 @@ use super::super::validators;
 
 pub type FormatBuilders = collections::HashMap<String, Box<super::Keyword + Send + Sync>>;
 
-static DATE_TIME_REGEX: regex::Regex = regex!(r"^(?i)(\d\d\d\d)-(\d\d)-(\d\d)T(\d\d):(\d\d):(\d\d)(\.\d+)??([+-]\d\d\d\d|[A-Z]+)$");
+lazy_static! {
+    static ref DATE_TIME_REGEX: regex::Regex = {
+       regex::Regex::new(r"^(?i)(\d\d\d\d)-(\d\d)-(\d\d)T(\d\d):(\d\d):(\d\d)(\.\d+)??([+-]\d\d\d\d|[A-Z]+)$").unwrap()
+    };
+}
 
 fn default_formats() -> FormatBuilders  {
     let mut map: FormatBuilders = collections::HashMap::new();

--- a/src/json_schema/keywords/mod.rs
+++ b/src/json_schema/keywords/mod.rs
@@ -3,7 +3,6 @@ use std::fmt;
 use std::rc;
 use std::collections;
 use std::any;
-use std::marker;
 
 use super::schema;
 use super::validators;
@@ -17,13 +16,11 @@ pub trait Keyword: Sync + any::Any {
     fn compile(&self, &json::Json, &schema::WalkContext) -> KeywordResult;
 }
 
-impl<T: 'static + Send + Sync + marker::Reflect> Keyword for T where T: Fn(&json::Json, &schema::WalkContext) -> KeywordResult {
+impl<T: 'static + Send + Sync + any::Any> Keyword for T where T: Fn(&json::Json, &schema::WalkContext) -> KeywordResult {
     fn compile(&self, def: &json::Json, ctx: &schema::WalkContext) -> KeywordResult {
         self(def, ctx)
     }
 }
-
-mopafy!(Keyword);
 
 impl fmt::Debug for Keyword + 'static {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {

--- a/src/json_schema/schema.rs
+++ b/src/json_schema/schema.rs
@@ -78,35 +78,7 @@ pub struct Schema {
     scopes: collections::HashMap<String, Vec<String>>
 }
 
-static PROPERTY_KEYS: phf::Set<&'static str> = phf_set! {
-    "properties",
-    "patternProperties",
-};
-
-static NON_SCHEMA_KEYS: phf::Set<&'static str> = phf_set! {
-    "properties",
-    "patternProperties",
-    "dependencies",
-    "definitions",
-    "anyOf",
-    "allOf",
-    "oneOf",
-};
-
-static FINAL_KEYS: phf::Set<&'static str> = phf_set! {
-    "enum",
-    "required",
-    "type"
-};
-
-const ALLOW_NON_CONSUMED_KEYS: phf::Set<&'static str> = phf_set! {
-    "definitions",
-    "$schema",
-    "id",
-    "default",
-    "description",
-    "format",
-};
+include!(concat!(env!("OUT_DIR"), "/codegen.rs"));
 
 pub struct CompilationSettings<'a> {
     pub keywords: &'a keywords::KeywordMap,
@@ -348,7 +320,7 @@ impl Schema {
         let mut state = validators::ValidationState::new();
 
         for validator in self.validators.iter() {
-            state.append(&mut validator.validate(data, path, scope))
+            state.append(validator.validate(data, path, scope))
         }
 
         state

--- a/src/json_schema/validators/dependencies.rs
+++ b/src/json_schema/validators/dependencies.rs
@@ -30,7 +30,7 @@ impl super::Validator for Dependencies {
                     &DepKind::Schema(ref url) => {
                         let schema = scope.resolve(url);
                         if schema.is_some() {
-                            state.append(&mut schema.unwrap().validate_in(object, path));
+                            state.append(schema.unwrap().validate_in(object, path));
                         } else {
                             state.missing.push(url.clone())
                         }

--- a/src/json_schema/validators/items.rs
+++ b/src/json_schema/validators/items.rs
@@ -38,7 +38,7 @@ impl super::Validator for Items {
                     let schema = schema.unwrap();
                     for (idx, item) in array.iter().enumerate() {
                         let item_path = [path, idx.to_string().as_ref()].connect("/");
-                        state.append(&mut schema.validate_in(item, item_path.as_ref()));
+                        state.append(schema.validate_in(item, item_path.as_ref()));
                     }
                 } else {
                     state.missing.push(url.clone());
@@ -54,7 +54,7 @@ impl super::Validator for Items {
 
                     if schema.is_some() {
                         let item_path = [path, idx.to_string().as_ref()].connect("/");
-                        state.append(&mut schema.unwrap().validate_in(item, item_path.as_ref()))
+                        state.append(schema.unwrap().validate_in(item, item_path.as_ref()))
                     } else {
                         state.missing.push(urls[idx].clone())
                     }
@@ -77,7 +77,7 @@ impl super::Validator for Items {
                                 let schema = schema.unwrap();
                                 for (idx, item) in array[urls.len()..].iter().enumerate() {
                                     let item_path = [path, idx.to_string().as_ref()].connect("/");
-                                    state.append(&mut schema.validate_in(item, item_path.as_ref()))
+                                    state.append(schema.validate_in(item, item_path.as_ref()))
                                 }
                             } else {
                                 state.missing.push(url.clone())

--- a/src/json_schema/validators/mod.rs
+++ b/src/json_schema/validators/mod.rs
@@ -99,9 +99,9 @@ impl ValidationState {
         self.errors.len() == 0 && self.missing.len() == 0
     }
 
-    pub fn append(&mut self, second: &mut ValidationState) {
-        self.errors.append(&mut second.errors);
-        self.missing.append(&mut second.missing);
+    pub fn append(&mut self, second: ValidationState) {
+        self.errors.extend(second.errors);
+        self.missing.extend(second.missing);
     }
 }
 

--- a/src/json_schema/validators/of.rs
+++ b/src/json_schema/validators/of.rs
@@ -17,7 +17,7 @@ impl super::Validator for AllOf {
             let schema = scope.resolve(url);
 
             if schema.is_some() {
-                state.append(&mut schema.unwrap().validate_in(val, path))
+                state.append(schema.unwrap().validate_in(val, path))
             } else {
                 state.missing.push(url.clone())
             }
@@ -44,7 +44,7 @@ impl super::Validator for AnyOf {
             if schema.is_some() {
                 let current_state = schema.unwrap().validate_in(val, path);
 
-                state.missing.append(&mut current_state.missing.clone());
+                state.missing.extend(current_state.missing.clone());
 
                 if current_state.is_valid() {
                     valid = true;
@@ -88,7 +88,7 @@ impl super::Validator for OneOf {
             if schema.is_some() {
                 let current_state = schema.unwrap().validate_in(val, path);
 
-                state.missing.append(&mut current_state.missing.clone());
+                state.missing.extend(current_state.missing.clone());
 
                 if current_state.is_valid() {
                     valid += 1;

--- a/src/json_schema/validators/properties.rs
+++ b/src/json_schema/validators/properties.rs
@@ -31,7 +31,7 @@ impl super::Validator for Properties {
                 let schema = scope.resolve(url);
                 if schema.is_some() {
                     let value_path = [path, key.as_ref()].connect("/");
-                    state.append(&mut schema.unwrap().validate_in(value, value_path.as_ref()))
+                    state.append(schema.unwrap().validate_in(value, value_path.as_ref()))
                 } else {
                     state.missing.push(url.clone())
                 }
@@ -45,7 +45,7 @@ impl super::Validator for Properties {
                     let schema = scope.resolve(url);
                     if schema.is_some() {
                         let value_path = [path, key.as_ref()].connect("/");
-                        state.append(&mut schema.unwrap().validate_in(value, value_path.as_ref()));
+                        state.append(schema.unwrap().validate_in(value, value_path.as_ref()));
                         is_pattern_passed = true;
                     } else {
                         state.missing.push(url.clone())
@@ -71,7 +71,7 @@ impl super::Validator for Properties {
 
                     if schema.is_some() {
                         let value_path = [path, key.as_ref()].connect("/");
-                        state.append(&mut schema.unwrap().validate_in(value, value_path.as_ref()))
+                        state.append(schema.unwrap().validate_in(value, value_path.as_ref()))
                     } else {
                         state.missing.push(url.clone())
                     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,12 +2,10 @@ extern crate rustc_serialize;
 extern crate regex;
 extern crate url;
 extern crate jsonway;
+#[macro_use] extern crate mopa;
 extern crate uuid;
 extern crate phf;
-#[macro_use]
-extern crate lazy_static;
-extern crate typeable;
-extern crate traitobject;
+#[macro_use] extern crate lazy_static;
 
 pub use mutable_json::MutableJson;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,18 +1,13 @@
-#![feature(core)]
-#![feature(collections)]
-#![feature(plugin)]
-
-#![plugin(phf_macros)]
-#![plugin(regex_macros)]
-
 extern crate rustc_serialize;
 extern crate regex;
 extern crate url;
 extern crate jsonway;
-#[macro_use] #[no_link]
-extern crate mopa;
 extern crate uuid;
 extern crate phf;
+#[macro_use]
+extern crate lazy_static;
+extern crate typeable;
+extern crate traitobject;
 
 pub use mutable_json::MutableJson;
 

--- a/tests/dsl/helpers.rs
+++ b/tests/dsl/helpers.rs
@@ -47,7 +47,7 @@ pub fn assert_error_with_scope<T: error::ValicoError>(params: &json_dsl::Builder
     let errors = get_errors(params, scope, body);
     println!("{:?}", errors);
     let error = errors.iter().find(|error| {
-        let err = (***error).downcast::<T>();
+        let err = error.downcast_ref::<T>();
         err.is_some() && err.unwrap().get_path() == path
     });
 

--- a/tests/dsl/helpers.rs
+++ b/tests/dsl/helpers.rs
@@ -28,7 +28,7 @@ pub fn get_errors(params: &json_dsl::Builder, scope: Option<&json_schema::Scope>
         Ok(mut json) => {
             let state = params.process(&mut json, &scope);
             if state.is_strictly_valid() {
-                panic!("Success responce when we await some errors");
+                panic!("Success response when we await some errors");
             } else {
                 return state.errors;
             }
@@ -43,11 +43,11 @@ pub fn assert_str_eq_with_scope(params: &json_dsl::Builder, scope: Option<&json_
     assert_eq!(test_result(params, scope, body).to_string(), res.to_string());
 }
 
-pub fn assert_error_with_scope<T: error::ValicoError + Send>(params: &json_dsl::Builder, scope: Option<&json_schema::Scope>, body: &str, path: &str) {
+pub fn assert_error_with_scope<T: error::ValicoError>(params: &json_dsl::Builder, scope: Option<&json_schema::Scope>, body: &str, path: &str) {
     let errors = get_errors(params, scope, body);
     println!("{:?}", errors);
     let error = errors.iter().find(|error| {
-        let err = error.downcast_ref::<T>();
+        let err = (***error).downcast::<T>();
         err.is_some() && err.unwrap().get_path() == path
     });
 
@@ -58,6 +58,6 @@ pub fn assert_str_eq(params: &json_dsl::Builder, body: &str, res: &str) {
     assert_str_eq_with_scope(params, None, body, res);
 }
 
-pub fn assert_error<T: error::ValicoError + Send>(params: &json_dsl::Builder, body: &str, path: &str) {
+pub fn assert_error<T: error::ValicoError>(params: &json_dsl::Builder, body: &str, path: &str) {
     assert_error_with_scope::<T>(params, None, body, path);
 }

--- a/tests/dsl/mod.rs
+++ b/tests/dsl/mod.rs
@@ -4,6 +4,7 @@ use valico::json_dsl;
 use valico::json_schema;
 use valico::json_schema::errors as schema_errors;
 use valico::json_dsl::errors;
+use regex;
 
 use self::helpers::{
     assert_str_eq_with_scope,
@@ -287,7 +288,7 @@ fn is_validates_with_regex() {
     let params = json_dsl::Builder::build(|params| {
         params.req("a", |a| {
             a.coerce(json_dsl::string());
-            a.regex(regex!("^test$"));
+            a.regex(regex::Regex::new("^test$").unwrap());
         })
     });
 
@@ -301,7 +302,7 @@ fn is_validates_with_regex() {
         params.req("a", |a| {
             // regex can't be applied to list, so it will never be valid
             a.coerce(json_dsl::array());
-            a.regex(regex!("^test$"));
+            a.regex(regex::Regex::new("^test$").unwrap());
         })
     });
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,7 +1,3 @@
-#![plugin(regex_macros)]
-#![feature(plugin)]
-#![feature(path_ext)]
-
 extern crate valico;
 extern crate rustc_serialize as serialize;
 


### PR DESCRIPTION
Fix for #9 

Summary:
* Replace `phf_macros` with `phf_codegen`
* Replace `regex_macros` with `lazy_static`
* Replace `mopy` with `typeable` and `traitobject`
* Replace `Vec::append` with `Extend::extend`
* Replace `path::is_file` with `File::metadata().is_file()`

All unit tests appear to be passing.