### PR TITLE
RFC 3339 conformity in the date parsing regex

### DIFF
--- a/src/json_schema/keywords/format.rs
+++ b/src/json_schema/keywords/format.rs
@@ -9,7 +9,7 @@ pub type FormatBuilders = collections::HashMap<String, Box<super::Keyword + Send
 
 lazy_static! {
     static ref DATE_TIME_REGEX: regex::Regex = {
-       regex::Regex::new(r"^(?i)(\d\d\d\d)-(\d\d)-(\d\d)T(\d\d):(\d\d):(\d\d)(\.\d+)??([+-]\d\d\d\d|[A-Z]+)$").unwrap()
+       regex::Regex::new(r"^(?i)(\d\d\d\d)-(\d\d)-(\d\d)T(\d\d):(\d\d):(\d\d)(\.\d+)??([+-]\d\d:?\d\d|[A-Z]+)$").unwrap()
     };
 }
 


### PR DESCRIPTION
The current regex does not allow for a colon in the time offset part of the regex. ISO 8601 permits this colon, whereas RFC 3339, which is a subset of said ISO spec, **requires** it to be there. This change makes it stay 8601 conformant while also making it accept RFC 3339 formatted dates.