### PR TITLE
Update to `serde` 1.0 with tests still passing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,13 +14,13 @@ build = "build.rs"
 regex = "0.1"
 lazy_static = "0.2"
 url = "1"
-jsonway = "1.0"
+jsonway = "2.0"
 uuid = {version = "0.3", features = ["v4"]}
 phf = "0.7"
 typeable = "0.1"
 traitobject = "0.0"
-serde = "0.8"
-serde_json = "0.8"
+serde = "1.0"
+serde_json = "1.0"
 
 [build-dependencies.phf_codegen]
 version = "0.7"

--- a/src/common/error.rs
+++ b/src/common/error.rs
@@ -29,13 +29,13 @@ impl ValicoError {
 }
 
 impl Serialize for ValicoError {
-    fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error> where S: Serializer {
-        let mut map = ::std::collections::BTreeMap::new();
-        map.insert("code".to_string(), to_value(self.get_code()));
-        map.insert("title".to_string(), to_value(self.get_title()));
-        map.insert("path".to_string(), to_value(self.get_path()));
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: Serializer {
+        let mut map = ::serde_json::Map::new();
+        map.insert("code".to_string(), to_value(self.get_code()).unwrap());
+        map.insert("title".to_string(), to_value(self.get_title()).unwrap());
+        map.insert("path".to_string(), to_value(self.get_path()).unwrap());
         match self.get_detail() {
-            Some(ref detail) => { map.insert("detail".to_string(), to_value(detail)); },
+            Some(ref detail) => { map.insert("detail".to_string(), to_value(detail).unwrap()); },
             None => ()
         }
         Value::Object(map).serialize(serializer)
@@ -97,13 +97,13 @@ macro_rules! impl_err {
 macro_rules! impl_serialize{
     ($err:ty) => {
         impl Serialize for $err {
-            fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error> where S: Serializer {
-                let mut map = ::std::collections::BTreeMap::new();
-                map.insert("code".to_string(), to_value(self.get_code()));
-                map.insert("title".to_string(), to_value(self.get_title()));
-                map.insert("path".to_string(), to_value(self.get_path()));
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: Serializer {
+                let mut map = ::serde_json::Map::new();
+                map.insert("code".to_string(), to_value(self.get_code()).unwrap());
+                map.insert("title".to_string(), to_value(self.get_title()).unwrap());
+                map.insert("path".to_string(), to_value(self.get_path()).unwrap());
                 match self.get_detail() {
-                    Some(ref detail) => { map.insert("detail".to_string(), to_value(detail)); },
+                    Some(ref detail) => { map.insert("detail".to_string(), to_value(detail).unwrap()); },
                     None => ()
                 }
                 Value::Object(map).serialize(serializer)
@@ -112,13 +112,13 @@ macro_rules! impl_serialize{
     };
     ($err:ty, $($sp:expr),+) => {
         impl Serialize for $err {
-            fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error> where S: Serializer {
-                let mut map = ::std::collections::BTreeMap::new();
-                map.insert("code".to_string(), to_value(self.get_code()));
-                map.insert("title".to_string(), to_value(self.get_title()));
-                map.insert("path".to_string(), to_value(self.get_path()));
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: Serializer {
+                let mut map = ::serde_json::Map::new();
+                map.insert("code".to_string(), to_value(self.get_code()).unwrap());
+                map.insert("title".to_string(), to_value(self.get_title()).unwrap());
+                map.insert("path".to_string(), to_value(self.get_path()).unwrap());
                 match self.get_detail() {
-                    Some(ref detail) => { map.insert("detail".to_string(), to_value(detail)); },
+                    Some(ref detail) => { map.insert("detail".to_string(), to_value(detail).unwrap()); },
                     None => ()
                 }
                 $({

--- a/src/json_dsl/builder.rs
+++ b/src/json_dsl/builder.rs
@@ -125,7 +125,7 @@ impl Builder {
         for param in self.requires.iter_mut().chain(self.optional.iter_mut()) {
             if param.schema_builder.is_some() {
                 let json_schema = json_schema::builder::schema_box(param.schema_builder.take().unwrap());
-                let id = try!(scope.compile(to_value(&json_schema), true));
+                let id = try!(scope.compile(to_value(&json_schema).unwrap(), true));
                 param.schema_id = Some(id);
             }
 
@@ -136,7 +136,7 @@ impl Builder {
 
         if self.schema_builder.is_some() {
             let json_schema = json_schema::builder::schema_box(self.schema_builder.take().unwrap());
-            let id = try!(scope.compile(to_value(&json_schema), true));
+            let id = try!(scope.compile(to_value(&json_schema).unwrap(), true));
             self.schema_id = Some(id);
         }
 

--- a/src/json_dsl/coercers.rs
+++ b/src/json_dsl/coercers.rs
@@ -33,7 +33,7 @@ impl Coercer for StringCoercer {
         if val.is_string() {
             Ok(None)
         } else if val.is_number() {
-            Ok(Some(to_value(&to_string(&val).unwrap())))
+            Ok(Some(to_value(&to_string(&val).unwrap()).unwrap()))
         } else {
             Err(vec![
                 Box::new(errors::WrongType {
@@ -55,15 +55,15 @@ impl Coercer for I64Coercer {
             return Ok(None)
         } else if val.is_u64() {
             let val = val.as_u64().unwrap();
-            return Ok(Some(to_value(&(val as i64))));
+            return Ok(Some(to_value(&(val as i64)).unwrap()));
         } else if val.is_f64() {
             let val = val.as_f64().unwrap();
-            return Ok(Some(to_value(&(val as i64))));
+            return Ok(Some(to_value(&(val as i64)).unwrap()));
         } else if val.is_string() {
             let val = val.as_str().unwrap();
             let converted: Option<i64> = val.parse().ok();
             match converted {
-                Some(num) => Ok(Some(to_value(&num))),
+                Some(num) => Ok(Some(to_value(&num).unwrap())),
                 None => Err(vec![
                     Box::new(errors::WrongType {
                         path: path.to_string(),
@@ -92,15 +92,15 @@ impl Coercer for U64Coercer {
             return Ok(None)
         } else if val.is_i64() {
             let val = val.as_i64().unwrap();
-            return Ok(Some(to_value(&(val as u64))));
+            return Ok(Some(to_value(&(val as u64)).unwrap()));
         } else if val.is_f64() {
             let val = val.as_f64().unwrap();
-            return Ok(Some(to_value(&(val as u64))));
+            return Ok(Some(to_value(&(val as u64)).unwrap()));
         } else if val.is_string() {
             let val = val.as_str().unwrap();
             let converted: Option<u64> = val.parse().ok();
             match converted {
-                Some(num) => Ok(Some(to_value(&num))),
+                Some(num) => Ok(Some(to_value(&num).unwrap())),
                 None => Err(vec![
                     Box::new(errors::WrongType {
                         path: path.to_string(),
@@ -129,15 +129,15 @@ impl Coercer for F64Coercer {
             return Ok(None)
         } else if val.is_i64() {
             let val = val.as_i64().unwrap();
-            return Ok(Some(to_value(&(val as f64))));
+            return Ok(Some(to_value(&(val as f64)).unwrap()));
         } else if val.is_u64() {
             let val = val.as_u64().unwrap();
-            return Ok(Some(to_value(&(val as f64))));
+            return Ok(Some(to_value(&(val as f64)).unwrap()));
         } else if val.is_string() {
             let val = val.as_str().unwrap();
             let converted: Option<f64> = val.parse().ok();
             match converted {
-                Some(num) => Ok(Some(to_value(&num))),
+                Some(num) => Ok(Some(to_value(&num).unwrap())),
                 None => Err(vec![
                     Box::new(errors::WrongType {
                         path: path.to_string(),

--- a/src/json_dsl/errors.rs
+++ b/src/json_dsl/errors.rs
@@ -2,7 +2,6 @@ use std::error::{Error};
 use super::super::common::error::ValicoError;
 use serde_json::{Value, to_value};
 use serde::{Serialize, Serializer};
-use std::collections;
 
 #[derive(Debug)]
 #[allow(missing_copy_implementations)]
@@ -39,8 +38,8 @@ pub struct MutuallyExclusive {
     pub params: Vec<String>
 }
 impl_err!(MutuallyExclusive, "mutually_exclusive", "The values are mutually exclusive", +opt_detail);
-impl_serialize!(MutuallyExclusive, |err: &MutuallyExclusive, map: &mut collections::BTreeMap<String, Value>| {
-    map.insert("params".to_string(), to_value(&err.params));
+impl_serialize!(MutuallyExclusive, |err: &MutuallyExclusive, map: &mut ::serde_json::Map<String, Value>| {
+    map.insert("params".to_string(), to_value(&err.params).unwrap());
 });
 
 #[derive(Debug)]
@@ -51,8 +50,8 @@ pub struct ExactlyOne {
     pub params: Vec<String>
 }
 impl_err!(ExactlyOne, "exactly_one", "Exacly one of the values must be present", +opt_detail);
-impl_serialize!(ExactlyOne, |err: &ExactlyOne, map: &mut collections::BTreeMap<String, Value>| {
-    map.insert("params".to_string(), to_value(&err.params))
+impl_serialize!(ExactlyOne, |err: &ExactlyOne, map: &mut ::serde_json::Map<String, Value>| {
+    map.insert("params".to_string(), to_value(&err.params).unwrap())
 });
 
 
@@ -64,6 +63,6 @@ pub struct AtLeastOne {
     pub params: Vec<String>
 }
 impl_err!(AtLeastOne, "at_least_one", "At least one of the values must be present", +opt_detail);
-impl_serialize!(AtLeastOne, |err: &AtLeastOne, map: &mut collections::BTreeMap<String, Value>| {
-    map.insert("params".to_string(), to_value(&err.params))
+impl_serialize!(AtLeastOne, |err: &AtLeastOne, map: &mut ::serde_json::Map<String, Value>| {
+    map.insert("params".to_string(), to_value(&err.params).unwrap())
 });

--- a/src/json_dsl/param.rs
+++ b/src/json_dsl/param.rs
@@ -176,17 +176,17 @@ impl Param {
 impl Param {
     pub fn allow_values<T: Serialize>(&mut self, values: &[T]) {
         self.validators.push(Box::new(validators::AllowedValues::new(
-            values.iter().map(|v| to_value(v)).collect()
+            values.iter().map(|v| to_value(v).unwrap()).collect()
         )));
     }
 
     pub fn reject_values<T: Serialize>(&mut self, values: &[T]) {
         self.validators.push(Box::new(validators::RejectedValues::new(
-            values.iter().map(|v| to_value(v)).collect()
+            values.iter().map(|v| to_value(v).unwrap()).collect()
         )));
     }
 
     pub fn default<T: Serialize>(&mut self, default: T) {
-        self.default = Some(to_value(&default));
+        self.default = Some(to_value(&default).unwrap());
     }
 }

--- a/src/json_schema/builder.rs
+++ b/src/json_schema/builder.rs
@@ -1,6 +1,6 @@
 use jsonway;
 use std::collections;
-use serde_json::{Value, to_value};
+use serde_json::value::{Value, to_value};
 use serde::{Serialize, Serializer};
 
 pub struct SchemaArray {
@@ -58,7 +58,7 @@ impl Dependencies {
 }
 
 impl Serialize for Dependencies {
-    fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error> where S: Serializer {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: Serializer {
         self.deps.serialize(serializer)
     }
 }
@@ -69,7 +69,7 @@ pub enum Dependency {
 }
 
 impl Serialize for Dependency {
-    fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error> where S: Serializer {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: Serializer {
         match self {
             &Dependency::Schema(ref json) => json.serialize(serializer),
             &Dependency::Property(ref array) => array.serialize(serializer)
@@ -236,7 +236,7 @@ impl Builder {
         self.obj_builder.set("type", type_.to_string())
     }
     pub fn types(&mut self, types: &[super::PrimitiveType]) {
-        self.obj_builder.set("type", to_value(&types.iter().map(|t| t.to_string()).collect::<Vec<String>>()))
+        self.obj_builder.set("type", to_value(&types.iter().map(|t| t.to_string()).collect::<Vec<String>>()).unwrap())
     }
 
     pub fn all_of<F>(&mut self, build: F) where F: FnOnce(&mut SchemaArray) {
@@ -273,7 +273,7 @@ impl Builder {
 }
 
 impl Serialize for Builder {
-    fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error> where S: Serializer {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: Serializer {
        self.obj_builder.serialize(serializer)
     }
 }

--- a/src/json_schema/errors.rs
+++ b/src/json_schema/errors.rs
@@ -2,7 +2,6 @@ use std::error::{Error};
 use super::super::common::error::ValicoError;
 use serde_json::{Value, to_value};
 use serde::{Serialize, Serializer};
-use std::collections;
 
 #[derive(Debug)]
 #[allow(missing_copy_implementations)]
@@ -142,8 +141,8 @@ pub struct AnyOf {
     pub states: Vec<super::validators::ValidationState>
 }
 impl_err!(AnyOf, "any_of", "AnyOf conditions are not met");
-impl_serialize!(AnyOf, |err: &AnyOf, map: &mut collections::BTreeMap<String, Value>| {
-    map.insert("states".to_string(), to_value(&err.states))
+impl_serialize!(AnyOf, |err: &AnyOf, map: &mut ::serde_json::Map<String, Value>| {
+    map.insert("states".to_string(), to_value(&err.states).unwrap())
 });
 
 #[derive(Debug)]
@@ -153,8 +152,8 @@ pub struct OneOf {
     pub states: Vec<super::validators::ValidationState>
 }
 impl_err!(OneOf, "one_of", "OneOf conditions are not met");
-impl_serialize!(OneOf, |err: &OneOf, map: &mut collections::BTreeMap<String, Value>| {
-    map.insert("states".to_string(), to_value(&err.states))
+impl_serialize!(OneOf, |err: &OneOf, map: &mut ::serde_json::Map<String, Value>| {
+    map.insert("states".to_string(), to_value(&err.states).unwrap())
 });
 
 #[derive(Debug)]

--- a/src/json_schema/helpers.rs
+++ b/src/json_schema/helpers.rs
@@ -28,7 +28,7 @@ pub fn connect(strings: &[&str]) -> String {
 }
 
 pub fn parse_url_key(key: &str, obj: &Value) -> Result<Option<Url>, schema::SchemaError> {
-    match obj.find(key) {
+    match obj.get(key) {
         Some(value) => {
             match value.as_str() {
                 Some(string) => Url::parse(string)
@@ -42,7 +42,7 @@ pub fn parse_url_key(key: &str, obj: &Value) -> Result<Option<Url>, schema::Sche
 }
 
 pub fn parse_url_key_with_base(key: &str, obj: &Value, base: &Url) -> Result<Option<Url>, schema::SchemaError> {
-    match obj.find(key) {
+    match obj.get(key) {
         Some(value) => {
             match value.as_str() {
                 Some(string) => Url::options()

--- a/src/json_schema/keywords/enum_.rs
+++ b/src/json_schema/keywords/enum_.rs
@@ -46,10 +46,10 @@ fn validate() {
         })
     }).into_json(), true).ok().unwrap();
 
-    assert_eq!(schema.validate(&to_value(&"prop1")).is_valid(), true);
-    assert_eq!(schema.validate(&to_value(&"prop2")).is_valid(), true);
-    assert_eq!(schema.validate(&to_value(&"prop3")).is_valid(), false);
-    assert_eq!(schema.validate(&to_value(&1)).is_valid(), false);
+    assert_eq!(schema.validate(&to_value(&"prop1").unwrap()).is_valid(), true);
+    assert_eq!(schema.validate(&to_value(&"prop2").unwrap()).is_valid(), true);
+    assert_eq!(schema.validate(&to_value(&"prop3").unwrap()).is_valid(), false);
+    assert_eq!(schema.validate(&to_value(&1).unwrap()).is_valid(), false);
 }
 
 #[test]

--- a/src/json_schema/keywords/format.rs
+++ b/src/json_schema/keywords/format.rs
@@ -99,9 +99,9 @@ fn validate_date_time() {
         s.format("date-time");
     }).into_json(), true).ok().unwrap();
 
-    assert_eq!(schema.validate(&to_value(&"2015-01-20T17:35:20-0800")).is_valid(), true);
-    assert_eq!(schema.validate(&to_value(&"1944-06-06T04:04:00Z")).is_valid(), true);
-    assert_eq!(schema.validate(&to_value(&"Tue, 20 Jan 2015 17:35:20 -0800")).is_valid(), false);
+    assert_eq!(schema.validate(&to_value(&"2015-01-20T17:35:20-0800").unwrap()).is_valid(), true);
+    assert_eq!(schema.validate(&to_value(&"1944-06-06T04:04:00Z").unwrap()).is_valid(), true);
+    assert_eq!(schema.validate(&to_value(&"Tue, 20 Jan 2015 17:35:20 -0800").unwrap()).is_valid(), false);
 }
 
 #[test]
@@ -111,9 +111,9 @@ fn validate_ipv4() {
         s.format("ipv4");
     }).into_json(), true).ok().unwrap();
 
-    assert_eq!(schema.validate(&to_value(&"127.0.0.1")).is_valid(), true);
-    assert_eq!(schema.validate(&to_value(&"8.8.8.8")).is_valid(), true);
-    assert_eq!(schema.validate(&to_value(&"::::0.0.0.0")).is_valid(), false);
+    assert_eq!(schema.validate(&to_value(&"127.0.0.1").unwrap()).is_valid(), true);
+    assert_eq!(schema.validate(&to_value(&"8.8.8.8").unwrap()).is_valid(), true);
+    assert_eq!(schema.validate(&to_value(&"::::0.0.0.0").unwrap()).is_valid(), false);
 }
 
 #[test]
@@ -123,8 +123,8 @@ fn validate_ipv6() {
         s.format("ipv6");
     }).into_json(), true).ok().unwrap();
 
-    assert_eq!(schema.validate(&to_value(&"FE80:0000:0000:0000:0202:B3FF:FE1E:8329")).is_valid(), true);
-    assert_eq!(schema.validate(&to_value(&"127.0.0.1")).is_valid(), false);
+    assert_eq!(schema.validate(&to_value(&"FE80:0000:0000:0000:0202:B3FF:FE1E:8329").unwrap()).is_valid(), true);
+    assert_eq!(schema.validate(&to_value(&"127.0.0.1").unwrap()).is_valid(), false);
 }
 
 #[test]
@@ -134,8 +134,8 @@ fn validate_uri() {
         s.format("uri");
     }).into_json(), true).ok().unwrap();
 
-    assert_eq!(schema.validate(&to_value(&"http://example.com")).is_valid(), true);
-    assert_eq!(schema.validate(&to_value(&"some-wrong")).is_valid(), false);
+    assert_eq!(schema.validate(&to_value(&"http://example.com").unwrap()).is_valid(), true);
+    assert_eq!(schema.validate(&to_value(&"some-wrong").unwrap()).is_valid(), false);
 }
 
 #[test]
@@ -145,7 +145,7 @@ fn validate_uuid() {
         s.format("uuid");
     }).into_json(), true).ok().unwrap();
 
-    assert_eq!(schema.validate(&to_value(&"2f5a2593-7481-49e2-9911-8fe2ad069aac")).is_valid(), true);
-    assert_eq!(schema.validate(&to_value(&"2f5a2593748149e299118fe2ad069aac")).is_valid(), true);
-    assert_eq!(schema.validate(&to_value(&"2f5a2593-7481-49e2-9911-8fe2ad06")).is_valid(), false);
+    assert_eq!(schema.validate(&to_value(&"2f5a2593-7481-49e2-9911-8fe2ad069aac").unwrap()).is_valid(), true);
+    assert_eq!(schema.validate(&to_value(&"2f5a2593748149e299118fe2ad069aac").unwrap()).is_valid(), true);
+    assert_eq!(schema.validate(&to_value(&"2f5a2593-7481-49e2-9911-8fe2ad06").unwrap()).is_valid(), false);
 }

--- a/src/json_schema/keywords/items.rs
+++ b/src/json_schema/keywords/items.rs
@@ -8,8 +8,8 @@ use super::super::helpers;
 pub struct Items;
 impl super::Keyword for Items {
     fn compile(&self, def: &Value, ctx: &schema::WalkContext) -> super::KeywordResult {
-        let maybe_items = def.find("items");
-        let maybe_additional = def.find("additionalItems");
+        let maybe_items = def.get("items");
+        let maybe_additional = def.get("additionalItems");
 
         if !(maybe_items.is_some() || maybe_additional.is_some()) {
             return Ok(None)
@@ -109,9 +109,9 @@ fn validate_items_with_schema() {
         });
     }).into_json(), true).ok().unwrap();
 
-    assert_eq!(schema.validate(&to_value(&[5,6,7,8,9,10])).is_valid(), true);
-    assert_eq!(schema.validate(&to_value(&[4,5,6,7,8,9,10])).is_valid(), false);
-    assert_eq!(schema.validate(&to_value(&[5,6,7,8,9,10,11])).is_valid(), false);
+    assert_eq!(schema.validate(&to_value(&[5,6,7,8,9,10]).unwrap()).is_valid(), true);
+    assert_eq!(schema.validate(&to_value(&[4,5,6,7,8,9,10]).unwrap()).is_valid(), false);
+    assert_eq!(schema.validate(&to_value(&[5,6,7,8,9,10,11]).unwrap()).is_valid(), false);
 }
 
 #[test]
@@ -130,12 +130,12 @@ fn validate_items_with_array_of_schemes() {
         })
     }).into_json(), true).ok().unwrap();
 
-    assert_eq!(schema.validate(&to_value(&[1])).is_valid(), true);
-    assert_eq!(schema.validate(&to_value(&[1,3])).is_valid(), true);
-    assert_eq!(schema.validate(&to_value(&[1,3,100])).is_valid(), true);
-    assert_eq!(schema.validate(&to_value(&[4,3])).is_valid(), false);
-    assert_eq!(schema.validate(&to_value(&[1,7])).is_valid(), false);
-    assert_eq!(schema.validate(&to_value(&[4,7])).is_valid(), false);
+    assert_eq!(schema.validate(&to_value(&[1]).unwrap()).is_valid(), true);
+    assert_eq!(schema.validate(&to_value(&[1,3]).unwrap()).is_valid(), true);
+    assert_eq!(schema.validate(&to_value(&[1,3,100]).unwrap()).is_valid(), true);
+    assert_eq!(schema.validate(&to_value(&[4,3]).unwrap()).is_valid(), false);
+    assert_eq!(schema.validate(&to_value(&[1,7]).unwrap()).is_valid(), false);
+    assert_eq!(schema.validate(&to_value(&[4,7]).unwrap()).is_valid(), false);
 }
 
 #[test]
@@ -155,7 +155,7 @@ fn validate_items_with_array_of_schemes_with_additional_bool() {
         s.additional_items(false);
     }).into_json(), true).ok().unwrap();
 
-    assert_eq!(schema.validate(&to_value(&[1,3,100])).is_valid(), false);
+    assert_eq!(schema.validate(&to_value(&[1,3,100]).unwrap()).is_valid(), false);
 }
 
 #[test]
@@ -177,6 +177,6 @@ fn validate_items_with_array_of_schemes_with_additional_schema() {
         });
     }).into_json(), true).ok().unwrap();
 
-    assert_eq!(schema.validate(&to_value(&[1,3,100])).is_valid(), true);
-    assert_eq!(schema.validate(&to_value(&[1,3,101])).is_valid(), false);
+    assert_eq!(schema.validate(&to_value(&[1,3,100]).unwrap()).is_valid(), true);
+    assert_eq!(schema.validate(&to_value(&[1,3,101]).unwrap()).is_valid(), false);
 }

--- a/src/json_schema/keywords/maxmin.rs
+++ b/src/json_schema/keywords/maxmin.rs
@@ -9,8 +9,8 @@ macro_rules! kw_minmax{
         pub struct $name;
         impl super::Keyword for $name {
             fn compile(&self, def: &Value, ctx: &schema::WalkContext) -> super::KeywordResult {
-                let maybe_value = def.find($keyword);
-                let exclusive = def.find($exclusive);
+                let maybe_value = def.get($keyword);
+                let exclusive = def.get($exclusive);
 
                 if exclusive.is_some() {
                     if !maybe_value.is_some() {
@@ -66,9 +66,9 @@ fn validate_maximum() {
         s.maximum(10f64, false);
     }).into_json(), true).ok().unwrap();
 
-    assert_eq!(schema.validate(&to_value(&9)).is_valid(), true);
-    assert_eq!(schema.validate(&to_value(&10)).is_valid(), true);
-    assert_eq!(schema.validate(&to_value(&11)).is_valid(), false);
+    assert_eq!(schema.validate(&to_value(&9).unwrap()).is_valid(), true);
+    assert_eq!(schema.validate(&to_value(&10).unwrap()).is_valid(), true);
+    assert_eq!(schema.validate(&to_value(&11).unwrap()).is_valid(), false);
 }
 
 #[test]
@@ -78,9 +78,9 @@ fn validate_exclusive_maximum() {
         s.maximum(10f64, true);
     }).into_json(), true).ok().unwrap();
 
-    assert_eq!(schema.validate(&to_value(&9)).is_valid(), true);
-    assert_eq!(schema.validate(&to_value(&10)).is_valid(), false);
-    assert_eq!(schema.validate(&to_value(&11)).is_valid(), false);
+    assert_eq!(schema.validate(&to_value(&9).unwrap()).is_valid(), true);
+    assert_eq!(schema.validate(&to_value(&10).unwrap()).is_valid(), false);
+    assert_eq!(schema.validate(&to_value(&11).unwrap()).is_valid(), false);
 }
 
 #[test]
@@ -113,9 +113,9 @@ fn validate_minumum() {
         s.minimum(10f64, false);
     }).into_json(), true).ok().unwrap();
 
-    assert_eq!(schema.validate(&to_value(&9)).is_valid(), false);
-    assert_eq!(schema.validate(&to_value(&10)).is_valid(), true);
-    assert_eq!(schema.validate(&to_value(&11)).is_valid(), true);
+    assert_eq!(schema.validate(&to_value(&9).unwrap()).is_valid(), false);
+    assert_eq!(schema.validate(&to_value(&10).unwrap()).is_valid(), true);
+    assert_eq!(schema.validate(&to_value(&11).unwrap()).is_valid(), true);
 }
 
 #[test]
@@ -125,9 +125,9 @@ fn validate_exclusive_minimum() {
         s.minimum(10f64, true);
     }).into_json(), true).ok().unwrap();
 
-    assert_eq!(schema.validate(&to_value(&9)).is_valid(), false);
-    assert_eq!(schema.validate(&to_value(&10)).is_valid(), false);
-    assert_eq!(schema.validate(&to_value(&11)).is_valid(), true);
+    assert_eq!(schema.validate(&to_value(&9).unwrap()).is_valid(), false);
+    assert_eq!(schema.validate(&to_value(&10).unwrap()).is_valid(), false);
+    assert_eq!(schema.validate(&to_value(&11).unwrap()).is_valid(), true);
 }
 
 #[test]

--- a/src/json_schema/keywords/maxmin_items.rs
+++ b/src/json_schema/keywords/maxmin_items.rs
@@ -18,9 +18,9 @@ fn validate_max_items() {
         s.max_items(5u64);
     }).into_json(), true).ok().unwrap();;
 
-    assert_eq!(schema.validate(&to_value(&[1,2,3,4])).is_valid(), true);
-    assert_eq!(schema.validate(&to_value(&[1,2,3,4,5])).is_valid(), true);
-    assert_eq!(schema.validate(&to_value(&[1,2,3,4,5,6])).is_valid(), false);
+    assert_eq!(schema.validate(&to_value(&[1,2,3,4]).unwrap()).is_valid(), true);
+    assert_eq!(schema.validate(&to_value(&[1,2,3,4,5]).unwrap()).is_valid(), true);
+    assert_eq!(schema.validate(&to_value(&[1,2,3,4,5,6]).unwrap()).is_valid(), false);
 }
 
 #[test]
@@ -28,15 +28,15 @@ fn malformed_max_items() {
     let mut scope = scope::Scope::new();
 
     assert!(scope.compile_and_return(jsonway::object(|schema| {
-        schema.set("maxItems", to_value(&-1));
+        schema.set("maxItems", to_value(&-1).unwrap());
     }).unwrap(), true).is_err());
 
     assert!(scope.compile_and_return(jsonway::object(|schema| {
-        schema.set("maxItems", to_value(&""));
+        schema.set("maxItems", to_value(&"").unwrap());
     }).unwrap(), true).is_err());
 
     assert!(scope.compile_and_return(jsonway::object(|schema| {
-        schema.set("maxItems", to_value(&1.1));
+        schema.set("maxItems", to_value(&1.1).unwrap());
     }).unwrap(), true).is_err());
 }
 
@@ -47,9 +47,9 @@ fn validate_min_items() {
         s.min_items(5u64);
     }).into_json(), true).ok().unwrap();;
 
-    assert_eq!(schema.validate(&to_value(&[1,2,3,4])).is_valid(), false);
-    assert_eq!(schema.validate(&to_value(&[1,2,3,4,5])).is_valid(), true);
-    assert_eq!(schema.validate(&to_value(&[1,2,3,4,5,6])).is_valid(), true);
+    assert_eq!(schema.validate(&to_value(&[1,2,3,4]).unwrap()).is_valid(), false);
+    assert_eq!(schema.validate(&to_value(&[1,2,3,4,5]).unwrap()).is_valid(), true);
+    assert_eq!(schema.validate(&to_value(&[1,2,3,4,5,6]).unwrap()).is_valid(), true);
 }
 
 #[test]
@@ -57,14 +57,14 @@ fn malformed_min_items() {
     let mut scope = scope::Scope::new();
 
     assert!(scope.compile_and_return(jsonway::object(|schema| {
-        schema.set("minItems", to_value(&-1));
+        schema.set("minItems", to_value(&-1).unwrap());
     }).unwrap(), true).is_err());
 
     assert!(scope.compile_and_return(jsonway::object(|schema| {
-        schema.set("minItems", to_value(&""));
+        schema.set("minItems", to_value(&"").unwrap());
     }).unwrap(), true).is_err());
 
     assert!(scope.compile_and_return(jsonway::object(|schema| {
-        schema.set("minItems", to_value(&1.1));
+        schema.set("minItems", to_value(&1.1).unwrap());
     }).unwrap(), true).is_err());
 }

--- a/src/json_schema/keywords/maxmin_length.rs
+++ b/src/json_schema/keywords/maxmin_length.rs
@@ -49,9 +49,9 @@ fn validate_max_length() {
         s.max_length(5u64);
     }).into_json(), true).ok().unwrap();;
 
-    assert_eq!(schema.validate(&to_value(&"1234")).is_valid(), true);
-    assert_eq!(schema.validate(&to_value(&"12345")).is_valid(), true);
-    assert_eq!(schema.validate(&to_value(&"123456")).is_valid(), false);
+    assert_eq!(schema.validate(&to_value(&"1234").unwrap()).is_valid(), true);
+    assert_eq!(schema.validate(&to_value(&"12345").unwrap()).is_valid(), true);
+    assert_eq!(schema.validate(&to_value(&"123456").unwrap()).is_valid(), false);
 }
 
 #[test]
@@ -59,15 +59,15 @@ fn malformed_max_length() {
     let mut scope = scope::Scope::new();
 
     assert!(scope.compile_and_return(jsonway::object(|schema| {
-        schema.set("maxLength", to_value(&-1));
+        schema.set("maxLength", to_value(&-1).unwrap());
     }).unwrap(), true).is_err());
 
     assert!(scope.compile_and_return(jsonway::object(|schema| {
-        schema.set("maxLength", to_value(&""));
+        schema.set("maxLength", to_value(&"").unwrap());
     }).unwrap(), true).is_err());
 
     assert!(scope.compile_and_return(jsonway::object(|schema| {
-        schema.set("maxLength", to_value(&1.1));
+        schema.set("maxLength", to_value(&1.1).unwrap());
     }).unwrap(), true).is_err());
 }
 
@@ -78,9 +78,9 @@ fn validate_min_length() {
         s.min_length(5u64);
     }).into_json(), true).ok().unwrap();;
 
-    assert_eq!(schema.validate(&to_value(&"1234")).is_valid(), false);
-    assert_eq!(schema.validate(&to_value(&"12345")).is_valid(), true);
-    assert_eq!(schema.validate(&to_value(&"123456")).is_valid(), true);
+    assert_eq!(schema.validate(&to_value(&"1234").unwrap()).is_valid(), false);
+    assert_eq!(schema.validate(&to_value(&"12345").unwrap()).is_valid(), true);
+    assert_eq!(schema.validate(&to_value(&"123456").unwrap()).is_valid(), true);
 }
 
 #[test]
@@ -88,14 +88,14 @@ fn malformed_min_length() {
     let mut scope = scope::Scope::new();
 
     assert!(scope.compile_and_return(jsonway::object(|schema| {
-        schema.set("minLength", to_value(&-1));
+        schema.set("minLength", to_value(&-1).unwrap());
     }).unwrap(), true).is_err());
 
     assert!(scope.compile_and_return(jsonway::object(|schema| {
-        schema.set("minLength", to_value(&""));
+        schema.set("minLength", to_value(&"").unwrap());
     }).unwrap(), true).is_err());
 
     assert!(scope.compile_and_return(jsonway::object(|schema| {
-        schema.set("minLength", to_value(&1.1));
+        schema.set("minLength", to_value(&1.1).unwrap());
     }).unwrap(), true).is_err());
 }

--- a/src/json_schema/keywords/maxmin_properties.rs
+++ b/src/json_schema/keywords/maxmin_properties.rs
@@ -39,15 +39,15 @@ fn malformed_max_properties() {
     let mut scope = scope::Scope::new();
 
     assert!(scope.compile_and_return(jsonway::object(|schema| {
-        schema.set("maxProperties", to_value(&-1));
+        schema.set("maxProperties", to_value(&-1).unwrap());
     }).unwrap(), true).is_err());
 
     assert!(scope.compile_and_return(jsonway::object(|schema| {
-        schema.set("maxProperties", to_value(&""));
+        schema.set("maxProperties", to_value(&"").unwrap());
     }).unwrap(), true).is_err());
 
     assert!(scope.compile_and_return(jsonway::object(|schema| {
-        schema.set("maxProperties", to_value(&1.1));
+        schema.set("maxProperties", to_value(&1.1).unwrap());
     }).unwrap(), true).is_err());
 }
 
@@ -79,14 +79,14 @@ fn malformed_min_properties() {
     let mut scope = scope::Scope::new();
 
     assert!(scope.compile_and_return(jsonway::object(|schema| {
-        schema.set("minProperties", to_value(&-1));
+        schema.set("minProperties", to_value(&-1).unwrap());
     }).unwrap(), true).is_err());
 
     assert!(scope.compile_and_return(jsonway::object(|schema| {
-        schema.set("minProperties", to_value(&""));
+        schema.set("minProperties", to_value(&"").unwrap());
     }).unwrap(), true).is_err());
 
     assert!(scope.compile_and_return(jsonway::object(|schema| {
-        schema.set("minProperties", to_value(&1.1));
+        schema.set("minProperties", to_value(&1.1).unwrap());
     }).unwrap(), true).is_err());
 }

--- a/src/json_schema/keywords/mod.rs
+++ b/src/json_schema/keywords/mod.rs
@@ -30,7 +30,7 @@ impl fmt::Debug for Keyword + 'static {
 
 macro_rules! keyword_key_exists {
     ($val:expr, $key:expr) => {{
-        let maybe_val = $val.find($key);
+        let maybe_val = $val.get($key);
         if maybe_val.is_none() {
             return Ok(None)
         } else {

--- a/src/json_schema/keywords/multiple_of.rs
+++ b/src/json_schema/keywords/multiple_of.rs
@@ -42,9 +42,9 @@ fn validate() {
         s.multiple_of(3.5f64);
     }).into_json(), true).ok().unwrap();
 
-    assert_eq!(schema.validate(&to_value(&"")).is_valid(), true);
-    assert_eq!(schema.validate(&to_value(&7)).is_valid(), true);
-    assert_eq!(schema.validate(&to_value(&6)).is_valid(), false);
+    assert_eq!(schema.validate(&to_value(&"").unwrap()).is_valid(), true);
+    assert_eq!(schema.validate(&to_value(&7).unwrap()).is_valid(), true);
+    assert_eq!(schema.validate(&to_value(&6).unwrap()).is_valid(), false);
 }
 
 #[test]
@@ -56,10 +56,10 @@ fn malformed() {
     }).unwrap(), true).is_err());
 
     assert!(scope.compile_and_return(jsonway::object(|schema| {
-        schema.set("multipleOf", to_value(&0));
+        schema.set("multipleOf", to_value(&0).unwrap());
     }).unwrap(), true).is_err());
 
     assert!(scope.compile_and_return(jsonway::object(|schema| {
-        schema.set("multipleOf", to_value(&-1));
+        schema.set("multipleOf", to_value(&-1).unwrap());
     }).unwrap(), true).is_err());
 }

--- a/src/json_schema/keywords/of.rs
+++ b/src/json_schema/keywords/of.rs
@@ -78,9 +78,9 @@ fn validate_all_of() {
         });
     }).into_json(), true).ok().unwrap();
 
-    assert_eq!(schema.validate(&to_value(&7)).is_valid(), true);
-    assert_eq!(schema.validate(&to_value(&4)).is_valid(), false);
-    assert_eq!(schema.validate(&to_value(&11)).is_valid(), false);
+    assert_eq!(schema.validate(&to_value(&7).unwrap()).is_valid(), true);
+    assert_eq!(schema.validate(&to_value(&4).unwrap()).is_valid(), false);
+    assert_eq!(schema.validate(&to_value(&11).unwrap()).is_valid(), false);
 }
 
 #[test]
@@ -97,9 +97,9 @@ fn validate_any_of() {
         });
     }).into_json(), true).ok().unwrap();
 
-    assert_eq!(schema.validate(&to_value(&5)).is_valid(), true);
-    assert_eq!(schema.validate(&to_value(&10)).is_valid(), true);
-    assert_eq!(schema.validate(&to_value(&11)).is_valid(), false);
+    assert_eq!(schema.validate(&to_value(&5).unwrap()).is_valid(), true);
+    assert_eq!(schema.validate(&to_value(&10).unwrap()).is_valid(), true);
+    assert_eq!(schema.validate(&to_value(&11).unwrap()).is_valid(), false);
 }
 
 #[test]
@@ -116,7 +116,7 @@ fn validate_one_of() {
         });
     }).into_json(), true).ok().unwrap();
 
-    assert_eq!(schema.validate(&to_value(&5)).is_valid(), false);
-    assert_eq!(schema.validate(&to_value(&6)).is_valid(), true);
-    assert_eq!(schema.validate(&to_value(&11)).is_valid(), false);
+    assert_eq!(schema.validate(&to_value(&5).unwrap()).is_valid(), false);
+    assert_eq!(schema.validate(&to_value(&6).unwrap()).is_valid(), true);
+    assert_eq!(schema.validate(&to_value(&11).unwrap()).is_valid(), false);
 }

--- a/src/json_schema/keywords/pattern.rs
+++ b/src/json_schema/keywords/pattern.rs
@@ -42,9 +42,9 @@ fn validate() {
         s.pattern(r"abb.*");
     }).into_json(), true).ok().unwrap();
 
-    assert_eq!(schema.validate(&to_value("abb")).is_valid(), true);
-    assert_eq!(schema.validate(&to_value("abbd")).is_valid(), true);
-    assert_eq!(schema.validate(&to_value("abd")).is_valid(), false);
+    assert_eq!(schema.validate(&to_value("abb").unwrap()).is_valid(), true);
+    assert_eq!(schema.validate(&to_value("abbd").unwrap()).is_valid(), true);
+    assert_eq!(schema.validate(&to_value("abd").unwrap()).is_valid(), false);
 }
 
 #[test]

--- a/src/json_schema/keywords/properties.rs
+++ b/src/json_schema/keywords/properties.rs
@@ -10,9 +10,9 @@ use super::super::helpers;
 pub struct Properties;
 impl super::Keyword for Properties {
     fn compile(&self, def: &Value, ctx: &schema::WalkContext) -> super::KeywordResult {
-        let maybe_properties = def.find("properties");
-        let maybe_additional = def.find("additionalProperties");
-        let maybe_pattern = def.find("patternProperties");
+        let maybe_properties = def.get("properties");
+        let maybe_additional = def.get("additionalProperties");
+        let maybe_pattern = def.get("patternProperties");
 
         if maybe_properties.is_none() && maybe_additional.is_none() && maybe_pattern.is_none() {
             return Ok(None)

--- a/src/json_schema/keywords/ref_.rs
+++ b/src/json_schema/keywords/ref_.rs
@@ -53,9 +53,9 @@ fn validate() {
     let array2: Vec<Vec<String>> = vec![vec![], vec![]];
     let array3: Vec<Vec<String>> = vec![vec![], vec![], vec![]];
 
-    assert_eq!(schema.validate(&to_value(&array)).is_valid(), true);
-    assert_eq!(schema.validate(&to_value(&array2)).is_valid(), true);
+    assert_eq!(schema.validate(&to_value(&array).unwrap()).is_valid(), true);
+    assert_eq!(schema.validate(&to_value(&array2).unwrap()).is_valid(), true);
 
-    assert_eq!(schema.validate(&to_value(&array3)).is_valid(), false);
-    assert_eq!(schema.validate(&to_value(&vec![1,2])).is_valid(), false);
+    assert_eq!(schema.validate(&to_value(&array3).unwrap()).is_valid(), false);
+    assert_eq!(schema.validate(&to_value(&vec![1,2]).unwrap()).is_valid(), false);
 }

--- a/src/json_schema/keywords/type_.rs
+++ b/src/json_schema/keywords/type_.rs
@@ -91,7 +91,7 @@ fn validate_array() {
     }).into_json(), true).ok().unwrap();
 
     assert_eq!(schema.validate(&jsonway::array(|_arr| {}).unwrap()).is_valid(), true);
-    assert_eq!(schema.validate(&to_value(&"string")).is_valid(), false);
+    assert_eq!(schema.validate(&to_value(&"string").unwrap()).is_valid(), false);
 }
 
 #[test]
@@ -101,9 +101,9 @@ fn validate_boolean() {
         s.boolean();
     }).into_json(), true).ok().unwrap();
 
-    assert_eq!(schema.validate(&to_value(&true)).is_valid(), true);
-    assert_eq!(schema.validate(&to_value(&false)).is_valid(), true);
-    assert_eq!(schema.validate(&to_value(&"string")).is_valid(), false);
+    assert_eq!(schema.validate(&to_value(&true).unwrap()).is_valid(), true);
+    assert_eq!(schema.validate(&to_value(&false).unwrap()).is_valid(), true);
+    assert_eq!(schema.validate(&to_value(&"string").unwrap()).is_valid(), false);
 }
 
 #[test]
@@ -113,10 +113,10 @@ fn validate_integer() {
         s.integer();
     }).into_json(), true).ok().unwrap();
 
-    assert_eq!(schema.validate(&to_value(&10)).is_valid(), true);
-    assert_eq!(schema.validate(&to_value(&-10)).is_valid(), true);
-    assert_eq!(schema.validate(&to_value(&11.5)).is_valid(), false);
-    assert_eq!(schema.validate(&to_value(&"string")).is_valid(), false);
+    assert_eq!(schema.validate(&to_value(&10).unwrap()).is_valid(), true);
+    assert_eq!(schema.validate(&to_value(&-10).unwrap()).is_valid(), true);
+    assert_eq!(schema.validate(&to_value(&11.5).unwrap()).is_valid(), false);
+    assert_eq!(schema.validate(&to_value(&"string").unwrap()).is_valid(), false);
 }
 
 #[test]
@@ -126,10 +126,10 @@ fn validate_number() {
         s.number();
     }).into_json(), true).ok().unwrap();
 
-    assert_eq!(schema.validate(&to_value(&10)).is_valid(), true);
-    assert_eq!(schema.validate(&to_value(&-10)).is_valid(), true);
-    assert_eq!(schema.validate(&to_value(&11.5)).is_valid(), true);
-    assert_eq!(schema.validate(&to_value(&"string")).is_valid(), false);
+    assert_eq!(schema.validate(&to_value(&10).unwrap()).is_valid(), true);
+    assert_eq!(schema.validate(&to_value(&-10).unwrap()).is_valid(), true);
+    assert_eq!(schema.validate(&to_value(&11.5).unwrap()).is_valid(), true);
+    assert_eq!(schema.validate(&to_value(&"string").unwrap()).is_valid(), false);
 }
 
 #[test]
@@ -140,7 +140,7 @@ fn validate_null() {
     }).into_json(), true).ok().unwrap();
 
     assert_eq!(schema.validate(&Value::Null).is_valid(), true);
-    assert_eq!(schema.validate(&to_value(&"string")).is_valid(), false);
+    assert_eq!(schema.validate(&to_value(&"string").unwrap()).is_valid(), false);
 }
 
 #[test]
@@ -151,7 +151,7 @@ fn validate_object() {
     }).into_json(), true).ok().unwrap();
 
     assert_eq!(schema.validate(&jsonway::object(|_arr| {}).unwrap()).is_valid(), true);
-    assert_eq!(schema.validate(&to_value(&"string")).is_valid(), false);
+    assert_eq!(schema.validate(&to_value(&"string").unwrap()).is_valid(), false);
 }
 
 #[test]
@@ -161,7 +161,7 @@ fn validate_string() {
         s.string();
     }).into_json(), true).ok().unwrap();
 
-    assert_eq!(schema.validate(&to_value(&"string")).is_valid(), true);
+    assert_eq!(schema.validate(&to_value(&"string").unwrap()).is_valid(), true);
     assert_eq!(schema.validate(&jsonway::object(|_arr| {}).unwrap()).is_valid(), false);
 }
 
@@ -172,10 +172,10 @@ fn validate_set() {
         s.types(&[super::super::PrimitiveType::Integer, super::super::PrimitiveType::String]);
     }).into_json(), true).ok().unwrap();
 
-    assert_eq!(schema.validate(&to_value(&10)).is_valid(), true);
-    assert_eq!(schema.validate(&to_value(&-11)).is_valid(), true);
-    assert_eq!(schema.validate(&to_value(&"string")).is_valid(), true);
-    assert_eq!(schema.validate(&to_value(&11.5)).is_valid(), false);
+    assert_eq!(schema.validate(&to_value(&10).unwrap()).is_valid(), true);
+    assert_eq!(schema.validate(&to_value(&-11).unwrap()).is_valid(), true);
+    assert_eq!(schema.validate(&to_value(&"string").unwrap()).is_valid(), true);
+    assert_eq!(schema.validate(&to_value(&11.5).unwrap()).is_valid(), false);
     assert_eq!(schema.validate(&jsonway::object(|_arr| {}).unwrap()).is_valid(), false);
 }
 

--- a/src/json_schema/keywords/unique_items.rs
+++ b/src/json_schema/keywords/unique_items.rs
@@ -35,6 +35,6 @@ fn validate_unique_items() {
         s.unique_items(true)
     }).into_json(), true).ok().unwrap();;
 
-    assert_eq!(schema.validate(&to_value(&[1,2,3,4])).is_valid(), true);
-    assert_eq!(schema.validate(&to_value(&[1,1,3,4])).is_valid(), false);
+    assert_eq!(schema.validate(&to_value(&[1,2,3,4]).unwrap()).is_valid(), true);
+    assert_eq!(schema.validate(&to_value(&[1,1,3,4]).unwrap()).is_valid(), false);
 }

--- a/src/json_schema/validators/dependencies.rs
+++ b/src/json_schema/validators/dependencies.rs
@@ -25,7 +25,7 @@ impl super::Validator for Dependencies {
         let mut state = super::ValidationState::new();
 
         for (key, dep) in self.items.iter() {
-            if object.find(key.as_ref()).is_some() {
+            if object.get(&key).is_some() {
                 match dep {
                     &DepKind::Schema(ref url) => {
                         let schema = scope.resolve(url);
@@ -37,7 +37,7 @@ impl super::Validator for Dependencies {
                     },
                     &DepKind::Property(ref keys) => {
                         for key in keys.iter() {
-                            if !object.find(key.as_ref()).is_some() {
+                            if !object.get(&key).is_some() {
                                 state.errors.push(Box::new(
                                     errors::Required {
                                         path: [path, key.as_ref()].join("/")

--- a/src/json_schema/validators/mod.rs
+++ b/src/json_schema/validators/mod.rs
@@ -107,13 +107,13 @@ impl ValidationState {
 }
 
 impl Serialize for ValidationState {
-    fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error> where S: Serializer {
-        let mut map = ::std::collections::BTreeMap::new();
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: Serializer {
+        let mut map = ::serde_json::Map::new();
         map.insert("errors".to_string(), Value::Array(
-            self.errors.iter().map(|err| to_value(err)).collect::<Vec<Value>>()
+            self.errors.iter().map(|err| to_value(err).unwrap()).collect::<Vec<Value>>()
         ));
         map.insert("missing".to_string(), Value::Array(
-            self.missing.iter().map(|url| to_value(&url.to_string())).collect::<Vec<Value>>()
+            self.missing.iter().map(|url| to_value(&url.to_string()).unwrap()).collect::<Vec<Value>>()
         ));
         Value::Object(map).serialize(serializer)
     }

--- a/tests/dsl/mod.rs
+++ b/tests/dsl/mod.rs
@@ -261,7 +261,7 @@ fn is_validates_with_function_validator() {
         params.req("a", |a| {
             a.coerce(json_dsl::u64());
             a.validate_with(|val: &Value, path: &str| {
-                if *val == Value::U64(2u64) {
+                if *val == Value::Number(::serde_json::Number::from(2u64)) {
                     Ok(())
                 } else {
                     Err(vec![

--- a/tests/schema/mod.rs
+++ b/tests/schema/mod.rs
@@ -77,7 +77,7 @@ fn test_suite() {
                             path.file_name().unwrap().to_str().unwrap(),
                             spec_desc,
                             description.to_string(),
-                            to_string_pretty(&to_value(&state)).unwrap()
+                            to_string_pretty(&to_value(&state).unwrap()).unwrap()
                         )
                     }
                 } else {


### PR DESCRIPTION
* BREAKING CHANGE: Force the current doc examples to `unwrap` their code, since now
    `serde_json::to_value` returns a `Result`.
* BREAKING CHANGE: Make downstream update any custom serializers they may have used to conform to the new `serde` API. This is expected, and not too big of a deal for people who want to upgrade to the new versions of `serde`. Basically, one only needs to change the `&mut S` argument to `S`, and use `S::Ok` instead of `()` for the `Result`.
* BREAKING CHANGE: Rename `find` usages in the docs to its isomorphic successor API `get`.
* BREAKING CHANGE: Replace `find_path` usages in the docs with usages of the new `pointer` API.

Closes issue #26.

---

NOTE that this PR is distinct from https://github.com/rustless/valico/pull/27, which has a few broken tests. This PR has ALL tests passing with minimum modifications necessary in order to make tests build again.

This PR depends on the [`serde` 1.0 bump that I've also submitted against `jsonway`](https://github.com/rustless/jsonway/pull/15). This PR **will** break in CI until that PR is merged and a new version of `jsonway` is accessible via `crates.io`. It may be interesting to discuss the following for this PR:

* I would question the necessity of `jsonway` for this library now that there is a `json!` macro in `serde_json` that seems to approach the same problem domain as that library. I probably don't know enough about it, though -- I'm not sure what the breadth of use cases are that `jsonway` intends to handle.
* The SemVer version bump that (I think) should accompany this change, since the APIs and docs have changed sufficiently to break most client code.