### PR TITLE
Notes need to clone with submodules in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,16 @@
 
 You want to contribute? You're awesome! When submitting a Pull Request, please have your commits follow these guidelines:
 
+## Getting source
+
+When cloning, ensure to clone recursively to get the submodules.
+
+    git clone --recurse-submodules git@github.com:rustless/valico.git
+
+If you've already cloned normally, use this to get the submodules:
+
+    git submodule update --init --recursive
+
 ## Git Commit Guidelines
 
 These guidelines have been copied from the [AngularJS](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#-git-commit-guidelines)


### PR DESCRIPTION
It's not immediately obvious that one must get the submodules in order to run tests!

Another way to fix this would be to make the test check to see if the directory exists instead of simply panicking.

Fixes #33