### PR TITLE
feat(json_schema): Adds a schema builder function for the description property

### DIFF
--- a/src/json_schema/builder.rs
+++ b/src/json_schema/builder.rs
@@ -103,6 +103,10 @@ impl Builder {
         self.obj_builder.set("$schema", url.to_string())
     }
 
+    pub fn desc(&mut self, text: &str) {
+        self.obj_builder.set("description", text.to_string())
+    }
+
     pub fn default<T>(&mut self, default: T) where T: Serialize {
         self.obj_builder.set("default", default)
     }


### PR DESCRIPTION
I'm having trouble tracking down where this is in the spec, but virtually every example linked from http://json-schema.org/examples.html contains descriptions within the top-level and property definitions.

This meets my needs for a more self-documenting schema.

If it's desirable, I'd like to do the same for the "title" property, although it only makes sense at the top level and I'm not sure how to limit it to that scope.