### PR TITLE
feat(json_schema): Adds title convenience method

### DIFF
--- a/src/json_schema/builder.rs
+++ b/src/json_schema/builder.rs
@@ -107,6 +107,10 @@ impl Builder {
         self.obj_builder.set("description", text.to_string())
     }
 
+    pub fn title(&mut self, text: &str) {
+        self.obj_builder.set("title", text.to_string())
+    }
+
     pub fn default<T>(&mut self, default: T) where T: Serialize {
         self.obj_builder.set("default", default)
     }


### PR DESCRIPTION
Title is only valid at the top level, but there is not currently a way
to limit that at compile time.