### PR TITLE
chore(Cargo.toml): bump version of regex

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ homepage = "https://github.com/rustless/valico"
 build = "build.rs"
 
 [dependencies]
-regex = "0.1"
+regex = "1.0"
 lazy_static = "0.2"
 url = "1"
 jsonway = "2.0"


### PR DESCRIPTION
I want to use valico in a tool I'm writing, but I had to get the `regex-syntax` crate to [update their licenses](https://github.com/rust-lang/regex/issues/530) to be able to use it in my org. The `valico` crate won't pull in these changes unless it uses the new version of the `regex` crate.

Bumping the version to `1.0` in the `Cargo.toml` still allows valico to build, so I'm hoping this change is pretty harmless.