### PR TITLE
refactor(lib, common): remove traitobject, typeable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,6 @@ url = "1"
 jsonway = "2.0"
 uuid = {version = "0.7", features = ["v4"]}
 phf = "0.7"
-typeable = "0.1"
-traitobject = "0.0"
 serde = "1.0"
 serde_json = "1.0"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,8 +4,6 @@ extern crate jsonway;
 extern crate uuid;
 extern crate phf;
 #[macro_use] extern crate lazy_static;
-extern crate typeable;
-extern crate traitobject;
 extern crate serde;
 extern crate serde_json;
 


### PR DESCRIPTION
Removes dependencies on the traitobject and typeable crates, as neither
crate includes a proper LICENSE file in the repo.

The author of both traitobject and typeable didn't include a LICENSE file in either repository, and [isn't responsive](https://github.com/reem/rust-traitobject/issues/4) to [github issues](https://github.com/reem/rust-typeable/issues/10) asking for this to be addressed. This is preventing me from using valico. Luckily, the changes necessary to remove these dependencies are fairly straightforward.

My apologies for not including this with my last PR.