### PR TITLE
Refresh tests dependency and formats

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,13 +12,14 @@ build = "build.rs"
 
 [dependencies]
 regex = "1.0"
-lazy_static = "0.2"
 url = "1"
 jsonway = "2.0"
 uuid = {version = "0.7", features = ["v4"]}
 phf = "0.7"
 serde = "1.0"
 serde_json = "1.0"
+chrono = "0.4.6"
+publicsuffix = "1.5.2"
 
 [build-dependencies.phf_codegen]
 version = "0.7"

--- a/src/json_schema/keywords/mod.rs
+++ b/src/json_schema/keywords/mod.rs
@@ -14,6 +14,10 @@ pub type KeywordMap = collections::HashMap<&'static str, rc::Rc<KeywordConsumer>
 
 pub trait Keyword: Sync + any::Any {
     fn compile(&self, &Value, &schema::WalkContext) -> KeywordResult;
+
+    fn is_exclusive(&self) -> bool {
+        false
+    }
 }
 
 impl<T: 'static + Send + Sync + any::Any> Keyword for T where T: Fn(&Value, &schema::WalkContext) -> KeywordResult {

--- a/src/json_schema/keywords/ref_.rs
+++ b/src/json_schema/keywords/ref_.rs
@@ -32,6 +32,10 @@ impl super::Keyword for Ref {
             })
         }
     }
+
+    fn is_exclusive(&self) -> bool {
+        true
+    }
 }
 
 #[cfg(test)] use super::super::scope;

--- a/src/json_schema/schema.rs
+++ b/src/json_schema/schema.rs
@@ -168,9 +168,21 @@ impl Schema {
                     Some(keyword) => {
                         keyword.consume(&mut keys);
 
+                        let is_exclusive_keyword = keyword.keyword.is_exclusive();
+
                         match try!(keyword.keyword.compile(def, context)) {
-                            Some(validator) => validators.push(validator),
+                            Some(validator) => {
+                                if is_exclusive_keyword {
+                                    validators = vec![validator];
+                                } else {
+                                    validators.push(validator);
+                                }
+                            },
                             None => ()
+                        };
+
+                        if is_exclusive_keyword {
+                            break;
                         }
                     },
                     None => {

--- a/src/json_schema/validators/formats.rs
+++ b/src/json_schema/validators/formats.rs
@@ -1,10 +1,75 @@
 use serde_json::{Value};
+use chrono;
 use std::net;
 use uuid;
 use url;
+use publicsuffix::List;
 
 use super::super::errors;
 use super::super::scope;
+
+#[allow(missing_copy_implementations)]
+pub struct DateTime;
+
+impl super::Validator for DateTime {
+    fn validate(&self, val: &Value, path: &str, _scope: &scope::Scope) -> super::ValidationState {
+        let string = nonstrict_process!(val.as_str(), path);
+
+        match chrono::DateTime::parse_from_rfc3339(string) {
+            Ok(_) => super::ValidationState::new(),
+            Err(_) => {
+                val_error!(
+                    errors::Format {
+                        path: path.to_string(),
+                        detail: "Malformed date time".to_string()
+                    }
+                )
+            }
+        }
+    }
+}
+
+#[allow(missing_copy_implementations)]
+pub struct Email;
+
+impl super::Validator for Email {
+    fn validate(&self, val: &Value, path: &str, _scope: &scope::Scope) -> super::ValidationState {
+        let string = nonstrict_process!(val.as_str(), path);
+
+        match List::empty().parse_email(string) {
+            Ok(_) => super::ValidationState::new(),
+            Err(_) => {
+                val_error!(
+                    errors::Format {
+                        path: path.to_string(),
+                        detail: "Malformed email address".to_string()
+                    }
+                )
+            }
+        }
+    }
+}
+
+#[allow(missing_copy_implementations)]
+pub struct Hostname;
+
+impl super::Validator for Hostname {
+    fn validate(&self, val: &Value, path: &str, _scope: &scope::Scope) -> super::ValidationState {
+        let string = nonstrict_process!(val.as_str(), path);
+
+        match List::empty().parse_domain(string) {
+            Ok(_) => super::ValidationState::new(),
+            Err(_) => {
+                val_error!(
+                    errors::Format {
+                        path: path.to_string(),
+                        detail: "Malformed email address".to_string()
+                    }
+                )
+            }
+        }
+    }
+}
 
 #[allow(missing_copy_implementations)]
 pub struct Ipv4;
@@ -19,7 +84,7 @@ impl super::Validator for Ipv4 {
                 val_error!(
                     errors::Format {
                         path: path.to_string(),
-                        detail: "Wrong IP address".to_string()
+                        detail: "Malformed IP address".to_string()
                     }
                 )
             }
@@ -40,7 +105,7 @@ impl super::Validator for Ipv6 {
                 val_error!(
                     errors::Format {
                         path: path.to_string(),
-                        detail: "Wrong IP address".to_string()
+                        detail: "Malformed IP address".to_string()
                     }
                 )
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,9 +3,10 @@ extern crate url;
 extern crate jsonway;
 extern crate uuid;
 extern crate phf;
-#[macro_use] extern crate lazy_static;
 extern crate serde;
 extern crate serde_json;
+extern crate chrono;
+extern crate publicsuffix;
 
 #[macro_use] pub mod common;
 pub mod json_dsl;

--- a/tests/schema/mod.rs
+++ b/tests/schema/mod.rs
@@ -52,12 +52,6 @@ fn test_suite() {
             ("bignum.json".to_string(), "a bignum is an integer".to_string()),
             ("bignum.json".to_string(), "a negative bignum is an integer".to_string()),
             ("ecmascript-regex.json".to_string(), "ECMA 262 has no support for \\Z anchor from .NET".to_string()),
-            ("format.json".to_string(), "a invalid day in date-time string".to_string()),
-            ("format.json".to_string(), "an invalid offset in date-time string".to_string()),
-            ("format.json".to_string(), "an invalid e-mail address".to_string()),
-            ("format.json".to_string(), "a host name starting with an illegal character".to_string()),
-            ("format.json".to_string(), "a host name containing illegal characters".to_string()),
-            ("format.json".to_string(), "a host name with a component too long".to_string()),
         ];
 
         for spec in spec_set.iter() {


### PR DESCRIPTION
I updated the dependency of JSON-Schema-Test-Suite to tag 2.0.0 (still on draft4, just updated tests).

In doing so I also noticed that:

- several formats are not implemented according to spec and reimplemented them (date-time, email, hostname).
- `$ref` behavior isn't identical to the spec (if there are other properties on the same level, they compose with the properties that the `$ref` is pointing to).