### PR TITLE
Disable unnecessary publicsuffix features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ phf = "0.7"
 serde = "1.0"
 serde_json = "1.0"
 chrono = "0.4.6"
-publicsuffix = "1.5.2"
+publicsuffix = { version = "1.5.2", default-features = false }
 
 [build-dependencies.phf_codegen]
 version = "0.7"


### PR DESCRIPTION
By default, publicsuffix pulls in native-tls in order to support
downloading the suffix list from publicsuffix.org. Unfortunately
native-tls doesn't yet support the fuchsia operating system. Since
valico doesn't use this part of publicsuffix, this patch just
removes the need for that dependency.

If this is accepted, would it be possible to also get a release to
go along with it? Thanks so much!