### PR TITLE
Display "Malformed hostname" when hostname format error occurs

### DIFF
--- a/src/json_schema/validators/formats.rs
+++ b/src/json_schema/validators/formats.rs
@@ -53,7 +53,7 @@ impl super::Validator for Hostname {
             Ok(_) => super::ValidationState::new(),
             Err(_) => val_error!(errors::Format {
                 path: path.to_string(),
-                detail: "Malformed email address".to_string()
+                detail: "Malformed hostname".to_string()
             }),
         }
     }


### PR DESCRIPTION
Fix to display "Malformed hostname" instead of "Malformed email address" when hostname format error occurs.

```rust
use serde_json;
use valico;

const SCHEMA_JSON: &str = r#"{
    "$schema": "http://json-schema.org/draft-07/schema#",
    "definitions": {
        "Foo": {
            "properties": {
                "bar": {
                    "format": "hostname",
                    "type": "string"
                }
            }
        }
    }
}"#;

#[derive(Debug, serde::Serialize)]
struct Foo {
    bar: String,
}

fn main() {
    let mut scope = valico::json_schema::Scope::new();

    let id = scope
        .compile(serde_json::from_str(SCHEMA_JSON).unwrap(), false)
        .unwrap();

    let schema = scope.resolve(&id).unwrap();

    let input_json = serde_json::to_value(&Foo {
        bar: "-a.aa".to_owned(),
    })
    .unwrap();

    let validation_state = valico::json_schema::schema::ScopedSchema::new(
        &scope,
        schema.resolve_fragment("/definitions/Foo").unwrap(),
    )
    .validate(&input_json);

    assert_eq!(
        validation_state.errors[0].get_detail().unwrap(),
        "Malformed hostname"
    );
}
```

```
[dependencies]
valico = { git = "https://github.com/hioki/valico", branch = "fix-detail-message" }
serde_json = "1.0.48"
serde_derive = "1.0.104"
serde = { version =  "1.0.104", features = ["derive"] }
```