### PR TITLE
fix(json_schema): Handle new draft6 tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Valico is a validation and coercion tool for JSON objects, written in Rust. It d
 Valico has two features:
 
 * **DSL** — a set of simple validators and coercers inspired by [Grape]. It has built-in support for common coercers, validators and can return detailed error messages if something goes wrong.
-* **JSON Schema** — An implementation of JSON Schema, based on IETF's draft v4.
+* **JSON Schema** — An implementation of JSON Schema, based on IETF's draft v6.
 
 References:
 

--- a/src/json_schema/helpers.rs
+++ b/src/json_schema/helpers.rs
@@ -1,4 +1,5 @@
 use serde_json::Value;
+use serde_json::Value::Number;
 use url::Url;
 use uuid::Uuid;
 
@@ -128,5 +129,15 @@ pub fn convert_boolean_schema(val: Value) -> Value {
             }
         }
         None => val,
+    }
+}
+
+pub fn is_matching(va: &Value, vb: &Value) -> bool {
+    match va {
+        Number(a) => match vb {
+            Number(b) => a.as_f64().unwrap() == b.as_f64().unwrap(),
+            _ => false,
+        },
+        _ => *va == *vb,
     }
 }

--- a/src/json_schema/validators/const_.rs
+++ b/src/json_schema/validators/const_.rs
@@ -1,6 +1,7 @@
 use serde_json::Value;
 
 use super::super::errors;
+use super::super::helpers::is_matching;
 use super::super::scope;
 
 #[allow(missing_copy_implementations)]
@@ -12,7 +13,7 @@ impl super::Validator for Const {
     fn validate(&self, val: &Value, path: &str, _scope: &scope::Scope) -> super::ValidationState {
         let mut state = super::ValidationState::new();
 
-        if *val != self.item {
+        if !is_matching(&self.item, val) {
             state.errors.push(Box::new(errors::Const {
                 path: path.to_string(),
             }))

--- a/src/json_schema/validators/enum_.rs
+++ b/src/json_schema/validators/enum_.rs
@@ -1,6 +1,7 @@
 use serde_json::Value;
 
 use super::super::errors;
+use super::super::helpers::is_matching;
 use super::super::scope;
 
 #[allow(missing_copy_implementations)]
@@ -14,7 +15,7 @@ impl super::Validator for Enum {
 
         let mut contains = false;
         for value in self.items.iter() {
-            if val == value {
+            if is_matching(val, value) {
                 contains = true;
                 break;
             }


### PR DESCRIPTION
New tests were added for the draft6. Notably the matching between booleans and numbers. But also some JS ECMA regex rules which the `regex` crate doesn't support - I skipped these tests but I don't know if `valico` should try hard to be compliant on these "optional" rules?