### PR TITLE
Fix clippy lints

### DIFF
--- a/src/json_schema/validators/content_media.rs
+++ b/src/json_schema/validators/content_media.rs
@@ -36,8 +36,8 @@ impl super::Validator for ContentMedia {
             None
         };
 
-        let val_ = if decoded_val.is_some() {
-            decoded_val.as_ref().unwrap()
+        let val_ = if let Some(decoded_val) = &decoded_val {
+            decoded_val
         } else {
             val
         };

--- a/src/json_schema/validators/formats.rs
+++ b/src/json_schema/validators/formats.rs
@@ -424,7 +424,7 @@ pub mod tests {
         let result = validate_regex("FOO\\");
         assert_eq!(result.errors.len(), 1);
 
-        let only_err = result.errors.get(0);
+        let only_err = result.errors.first();
         assert!(only_err.is_some());
 
         let err = only_err.unwrap();

--- a/tests/schema/mod.rs
+++ b/tests/schema/mod.rs
@@ -9,7 +9,7 @@ where
     F: Fn(&path::Path, Value) + Copy,
 {
     let mut contents = fs::read_dir(dir)
-        .unwrap_or_else(|_| panic!("cannot list directory {dir:?}"))
+        .unwrap_or_else(|_| panic!("cannot list directory {:?}", dir))
         .collect::<Vec<_>>();
     contents.sort_by_key(|v| v.as_ref().unwrap().file_name());
     for entry in contents {


### PR DESCRIPTION
Regarding the panic, the `panic!("... {dir:?}")` syntax is only supported in the rust 2021 edition, but valico is only using rust 2018.