### PR TITLE
Valico does not use chrono's clock and std features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ uuid = { version = "1", features = ["v4"] }
 phf = "0.11"
 serde = "1"
 serde_json = "1"
-chrono = { version = "0.4.23", default-features = false, features = ["clock", "std"] }
+chrono = { version = "0.4.23", default-features = false }
 addr = "0.15.6"
 percent-encoding = "2.2.0"
 json-pointer = "0.3.4"

--- a/src/json_schema/validators/content_media.rs
+++ b/src/json_schema/validators/content_media.rs
@@ -36,8 +36,8 @@ impl super::Validator for ContentMedia {
             None
         };
 
-        let val_ = if decoded_val.is_some() {
-            decoded_val.as_ref().unwrap()
+        let val_ = if let Some(decoded_val) = &decoded_val {
+            decoded_val
         } else {
             val
         };

--- a/src/json_schema/validators/formats.rs
+++ b/src/json_schema/validators/formats.rs
@@ -424,7 +424,7 @@ pub mod tests {
         let result = validate_regex("FOO\\");
         assert_eq!(result.errors.len(), 1);
 
-        let only_err = result.errors.get(0);
+        let only_err = result.errors.first();
         assert!(only_err.is_some());
 
         let err = only_err.unwrap();

--- a/tests/schema/mod.rs
+++ b/tests/schema/mod.rs
@@ -9,7 +9,7 @@ where
     F: Fn(&path::Path, Value) + Copy,
 {
     let mut contents = fs::read_dir(dir)
-        .unwrap_or_else(|_| panic!("cannot list directory {dir:?}"))
+        .unwrap_or_else(|_| panic!("cannot list directory {:?}", dir))
         .collect::<Vec<_>>();
     contents.sort_by_key(|v| v.as_ref().unwrap().file_name());
     for entry in contents {


### PR DESCRIPTION
This reduces the chrono feature sets to reduce the number of dependencies downstream users need to download.